### PR TITLE
enhance: 실패한 도구가 있을 경우 exitCode 1 로 종료

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -62,6 +62,7 @@ export class LintCommand extends BaseCommand {
 
 		if (failedTools.length > 0) {
 			console.error(`✗ Failed: ${failedTools.join(", ")}`)
+			process.exitCode = 1
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The lint command now exits with a non-zero status when any lint tool fails. This ensures CI pipelines and scripts correctly detect lint failures without forcing an immediate process termination. Improves reliability of automated checks, makes failure states explicit, and aligns exit behavior with common CLI expectations. No changes to public APIs or command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->